### PR TITLE
fix(equal/3, embed_as): equal/3 should rely on Money.equal/2

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,10 +14,10 @@ config :ex_money,
   default_cldr_backend: Money.Cldr
 
 config :ex_money_sql, Money.SQL.Repo,
-    username: "kip",
-    database: "money_dev",
-    hostname: "localhost",
-    pool: Ecto.Adapters.SQL.Sandbox
+  username: "kip",
+  database: "money_dev",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox
 
 config :ex_money_sql,
   ecto_repos: [Money.SQL.Repo]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,10 +14,10 @@ config :ex_money,
   default_cldr_backend: Money.Cldr
 
 config :ex_money_sql, Money.SQL.Repo,
-    username: "kip",
-    database: "money_dev",
-    hostname: "localhost",
-    pool: Ecto.Adapters.SQL.Sandbox
+  username: "kip",
+  database: "money_dev",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox
 
 config :ex_money_sql,
   ecto_repos: [Money.SQL.Repo]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,10 +1,10 @@
 import Config
 
 config :ex_money_sql, Money.SQL.Repo,
-    username: "kip",
-    database: "money_dev",
-    hostname: "localhost",
-    pool: Ecto.Adapters.SQL.Sandbox
+  username: "kip",
+  database: "money_dev",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox
 
 config :ex_money_sql,
   ecto_repos: [Money.SQL.Repo]

--- a/lib/money/ddl.ex
+++ b/lib/money/ddl.ex
@@ -164,10 +164,11 @@ defmodule Money.DDL do
 
   defp read_sql_file(db_type, file_name) do
     raise ArgumentError,
-          "Database type #{db_type} does not have a SQL definition " <> "file #{inspect(file_name)}"
+          "Database type #{db_type} does not have a SQL definition " <>
+            "file #{inspect(file_name)}"
   end
 
-  @app Mix.Project.config[:app]
+  @app Mix.Project.config()[:app]
   defp base_dir(db_type) do
     :code.priv_dir(@app)
     |> Path.join(["SQL", "/#{db_type}"])

--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -124,7 +124,9 @@ if Code.ensure_loaded?(Ecto.Type) do
       :error
     end
 
-		@impl Ecto.ParameterizedType
+    def equal?(money1, money2), do: equal?(money1, money2, [])
+
+    @impl Ecto.ParameterizedType
     def equal?(money1, money2, _params) do
       Money.equal?(money1, money2)
     end

--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -124,6 +124,11 @@ if Code.ensure_loaded?(Ecto.Type) do
       :error
     end
 
+    def embed_as(term), do: embed_as(term, [])
+
+    @impl Ecto.ParameterizedType
+    def embed_as(_term, _params), do: :self
+
     def equal?(money1, money2), do: equal?(money1, money2, [])
 
     @impl Ecto.ParameterizedType

--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -10,7 +10,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     use Ecto.ParameterizedType
 
-		@impl Ecto.ParameterizedType
+    @impl Ecto.ParameterizedType
     def type(_params) do
       :money_with_currency
     end
@@ -19,7 +19,7 @@ if Code.ensure_loaded?(Ecto.Type) do
       Ecto.ParameterizedType.init(__MODULE__, opts)
     end
 
-		@impl Ecto.ParameterizedType
+    @impl Ecto.ParameterizedType
     def init(opts) do
       opts
       |> Keyword.delete(:field)
@@ -29,7 +29,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     # When loading from the database
 
-		@impl Ecto.ParameterizedType
+    @impl Ecto.ParameterizedType
     def load(tuple, loader \\ nil, params \\ [])
 
     def load(nil, _loader, _params) do
@@ -48,7 +48,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     # since we are dumping from %Money{} structs that the
     # data is ok
 
-		@impl Ecto.ParameterizedType
+    @impl Ecto.ParameterizedType
     def dump(money, dumper \\ nil, params \\ [])
 
     def dump(%Money{} = money, _dumper, _params) do
@@ -66,10 +66,10 @@ if Code.ensure_loaded?(Ecto.Type) do
     # Casting in changesets
 
     def cast(money) do
-			cast(money, [])
-		end
+      cast(money, [])
+    end
 
-		@impl Ecto.ParameterizedType
+    @impl Ecto.ParameterizedType
     def cast(nil, _params) do
       {:ok, nil}
     end
@@ -115,7 +115,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     def cast(string, params) when is_binary(string) do
       case Money.parse(string, params) do
-        {:error,{_, message}} -> {:error, message: message}
+        {:error, {_, message}} -> {:error, message: message}
         money -> {:ok, money}
       end
     end

--- a/lib/money/ecto/money_ecto_map_type.ex
+++ b/lib/money/ecto/money_ecto_map_type.ex
@@ -21,8 +21,8 @@ if Code.ensure_loaded?(Ecto.Type) do
     defdelegate cast(money, params), to: Money.Ecto.Composite.Type
 
     # New for ecto_sql 3.2
-    defdelegate  embed_as(term, params), to: Money.Ecto.Composite.Type
-    defdelegate  equal?(term1, term2, params), to: Money.Ecto.Composite.Type
+    defdelegate embed_as(term, params), to: Money.Ecto.Composite.Type
+    defdelegate equal?(term1, term2, params), to: Money.Ecto.Composite.Type
 
     def type(_params) do
       :map
@@ -34,7 +34,8 @@ if Code.ensure_loaded?(Ecto.Type) do
       {:ok, nil}
     end
 
-    def load(%{"currency" => currency, "amount" => amount}, _loader, params) when is_binary(amount) do
+    def load(%{"currency" => currency, "amount" => amount}, _loader, params)
+        when is_binary(amount) do
       with {amount, ""} <- Cldr.Decimal.parse(amount),
            {:ok, currency} <- Money.validate_currency(currency) do
         {:ok, Money.new(currency, amount, params)}
@@ -43,7 +44,8 @@ if Code.ensure_loaded?(Ecto.Type) do
       end
     end
 
-    def load(%{"currency" => currency, "amount" => amount}, _loader, params) when is_integer(amount) do
+    def load(%{"currency" => currency, "amount" => amount}, _loader, params)
+        when is_integer(amount) do
       with {:ok, currency} <- Money.validate_currency(currency) do
         {:ok, Money.new(currency, amount, params)}
       else
@@ -64,6 +66,5 @@ if Code.ensure_loaded?(Ecto.Type) do
     def dump(_, _, _) do
       :error
     end
-
   end
 end

--- a/lib/money/ecto/money_ecto_map_type.ex
+++ b/lib/money/ecto/money_ecto_map_type.ex
@@ -22,6 +22,7 @@ if Code.ensure_loaded?(Ecto.Type) do
 
     # New for ecto_sql 3.2
     defdelegate embed_as(term, params), to: Money.Ecto.Composite.Type
+    defdelegate equal?(term1, term2), to: Money.Ecto.Composite.Type
     defdelegate equal?(term1, term2, params), to: Money.Ecto.Composite.Type
 
     def type(_params) do

--- a/lib/money/ecto/money_ecto_map_type.ex
+++ b/lib/money/ecto/money_ecto_map_type.ex
@@ -21,6 +21,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     defdelegate cast(money, params), to: Money.Ecto.Composite.Type
 
     # New for ecto_sql 3.2
+    defdelegate embed_as(term), to: Money.Ecto.Composite.Type
     defdelegate embed_as(term, params), to: Money.Ecto.Composite.Type
     defdelegate equal?(term1, term2), to: Money.Ecto.Composite.Type
     defdelegate equal?(term1, term2, params), to: Money.Ecto.Composite.Type

--- a/lib/money_sql.ex
+++ b/lib/money_sql.ex
@@ -1,5 +1,4 @@
 defmodule Money.Sql do
   @moduledoc false
-  #require Money
-
+  # require Money
 end

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Money.Sql.Mixfile do
 
   defp aliases do
     [
-     test: ["ecto.drop --quiet", "ecto.create --quiet", "ecto.migrate --quiet", "test"]
+      test: ["ecto.drop --quiet", "ecto.create --quiet", "ecto.migrate --quiet", "test"]
     ]
   end
 

--- a/test/money_changeset_test.exs
+++ b/test/money_changeset_test.exs
@@ -5,6 +5,4 @@ defmodule Money.Changeset.Test do
     changeset = Organization.changeset(%Organization{}, %{payroll: "0"})
     assert changeset.changes.payroll == Money.new(:JPY, 0)
   end
-
-
 end

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -107,15 +107,16 @@ defmodule Money.Ecto.Test do
 
     test "#{inspect(ecto_type_module)}: cast a string that includes currency code and localised amount" do
       # "de"
-      locale = Test.Cldr.get_locale
-      Test.Cldr.put_locale "de"
+      locale = Test.Cldr.get_locale()
+      Test.Cldr.put_locale("de")
       assert unquote(ecto_type_module).cast("100,00 USD") == {:ok, Money.new("100,00", :USD)}
-      Test.Cldr.put_locale locale
+      Test.Cldr.put_locale(locale)
     end
 
     test "#{inspect(ecto_type_module)}: cast an invalid string is an error" do
       assert unquote(ecto_type_module).cast("100 USD and other stuff") ==
-        {:error,  message: "The currency \"USD and other stuff\" is unknown or not supported"}
+               {:error,
+                message: "The currency \"USD and other stuff\" is unknown or not supported"}
     end
 
     test "#{inspect(ecto_type_module)}: cast anything else is an error" do
@@ -128,7 +129,10 @@ defmodule Money.Ecto.Test do
 
     test "#{inspect(ecto_type_module)}: cast localized amount error does not raise" do
       Cldr.put_locale(Money.Cldr, "de")
-      assert unquote(ecto_type_module).cast(%{currency: :NOK, amount: "218,75"}) == {:ok, Money.from_float(:NOK, 218.75)}
+
+      assert unquote(ecto_type_module).cast(%{currency: :NOK, amount: "218,75"}) ==
+               {:ok, Money.from_float(:NOK, 218.75)}
+
       Cldr.put_locale(Money.Cldr, "en")
     end
 

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -147,5 +147,19 @@ defmodule Money.Ecto.Test do
     test "#{inspect(ecto_type_module)}: load nil returns nil" do
       assert unquote(ecto_type_module).load(nil) == {:ok, nil}
     end
+
+    test "#{inspect(ecto_type_module)}: equal? two equal money struct returns true" do
+      assert unquote(ecto_type_module).equal?(
+               Money.new(:USD, 100),
+               Money.new(:USD, Decimal.new("100.0"))
+             ) == true
+    end
+
+    test "#{inspect(ecto_type_module)}: equal? two unequal money struct returns false" do
+      assert unquote(ecto_type_module).equal?(
+               Money.new(:USD, 100),
+               Money.new(:USD, Decimal.new("200.0"))
+             ) == false
+    end
   end
 end

--- a/test/money_sql_test.exs
+++ b/test/money_sql_test.exs
@@ -1,3 +1,2 @@
 defmodule MoneySqlTest do
-
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,5 @@
 ExUnit.start()
-{:ok, _pid} = Money.SQL.Repo.start_link
+{:ok, _pid} = Money.SQL.Repo.start_link()
 :ok = Ecto.Adapters.SQL.Sandbox.mode(Money.SQL.Repo, :manual)
 
 defmodule Money.SQL.RepoCase do
@@ -26,7 +26,4 @@ defmodule Money.SQL.RepoCase do
 
     :ok
   end
-
-
 end
-


### PR DESCRIPTION
The default implementation from Ecto for `Ecto.ParameterizedType.equal/3` is doing 

```
def equal?(term1, term2, _params), do: term1 == term2
```
which results in changeset wrongly reporting changes although params passed are equal to model's value when compared using `Money.equal/2`.

Instead, `Money.equal/2` should be used for money comparison.

Ref: https://github.com/elixir-ecto/ecto/blob/dc568c3b619a71511b275e609c89e530c011da04/lib/ecto/parameterized_type.ex#L190

Also added function head and base implementation for `embed_as` that is defdelegated from `Money.Ecto.Map.Type` to  `Money.Ecto.Composite.Type`.