### PR TITLE
enhancement enabling postgres parallel queries

### DIFF
--- a/priv/repo/migrations/20220719233541_add_postgres_money_aggregate_functions.exs
+++ b/priv/repo/migrations/20220719233541_add_postgres_money_aggregate_functions.exs
@@ -36,16 +36,45 @@ defmodule Money.SQL.Repo.Migrations.AddPostgresMoneyAggregateFunctions do
     """)
 
     execute("""
+    CREATE OR REPLACE FUNCTION money_combine_function(agg_state1 money_with_currency, agg_state2 money_with_currency)
+    RETURNS money_with_currency
+    IMMUTABLE
+    STRICT
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        IF currency_code(agg_state1) = currency_code(agg_state2) THEN
+          return row(currency_code(agg_state1), amount(agg_state1) + amount(agg_state2));
+        ELSE
+          RAISE EXCEPTION
+            'Incompatible currency codes. Expected all currency codes to be %', expected_currency
+            USING HINT = 'Please ensure all columns have the same currency code',
+            ERRCODE = '22033';
+        END IF;
+      END;
+    $$;
+    """)
+
+
+
+    execute("""
     CREATE AGGREGATE sum(money_with_currency)
     (
       sfunc = money_state_function,
-      stype = money_with_currency
+      stype = money_with_currency,
+      combinefunc = money_combine_function,
+      parallel = SAFE
     );
     """)
   end
 
   def down do
     execute("DROP AGGREGATE IF EXISTS sum(money_with_currency);")
+
+    execute(
+      "DROP FUNCTIION IF EXISTS money_combine_function(agg_state1 money_with_currency, agg_state2 money_with_currency);"
+      )
+
 
     execute(
       "DROP FUNCTION IF EXISTS money_state_function(agg_state money_with_currency, money money_with_currency);"


### PR DESCRIPTION
Fix to enable parallel queries for aggregate function. 

This adds the combine function to the aggregate and the parallel = SAFE flag.

Significant gains in performance as expected based on postgres max_parallel_workers_per_gather (default 2) and max_parallel_workers config variables. 