### PR TITLE
Cast a map with the current structure but a nil amount

### DIFF
--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -84,6 +84,10 @@ if Code.ensure_loaded?(Ecto.Type) do
       {:ok, nil}
     end
 
+    def cast(%{"currency" => _, "amount" => nil}, _params) do
+      {:ok, nil}
+    end
+
     def cast(%{"currency" => nil, "amount" => _amount}, _params) do
       {:error, exception: Money.UnknownCurrencyError, message: "Currency must not be `nil`"}
     end

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -68,6 +68,10 @@ defmodule Money.Ecto.Test do
       assert unquote(ecto_type_module).cast(%{"currency" => "USD", "amount" => ""}) == {:ok, nil}
     end
 
+    test "#{inspect(ecto_type_module)}: cast a map with the current structure but a nil amount" do
+      assert unquote(ecto_type_module).cast(%{"currency" => "USD", "amount" => nil}) == {:ok, nil}
+    end
+
     test "#{inspect(ecto_type_module)}: cast a money struct" do
       assert unquote(ecto_type_module).cast(Money.new(:USD, 100)) == {:ok, Money.new(:USD, 100)}
     end


### PR DESCRIPTION
Hi Kipcole9,
I was using your library and I found out that when you cast a value like `%{amount: "", currency: "EUR"}` I get a `nil`. 

When I do the same with `%{amount: nil, currency: "EUR"}` I get an error while I'm expecting a `nil`.

This PR fix this

Hi! Andrea