### PR TITLE
Fix Ecto parameterized types to work with embeds

### DIFF
--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -137,7 +137,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     def embed_as(term), do: embed_as(term, [])
 
     @impl Ecto.ParameterizedType
-    def embed_as(_term, _params), do: :self
+    def embed_as(_term, _params), do: :dump
 
     def equal?(money1, money2), do: equal?(money1, money2, [])
 

--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -46,6 +46,10 @@ if Code.ensure_loaded?(Ecto.Type) do
       end
     end
 
+    def load(_, _, _) do
+      :error
+    end
+
     # Dumping to the database.  We make the assumption that
     # since we are dumping from %Money{} structs that the
     # data is ok

--- a/lib/money/ecto/money_ecto_map_type.ex
+++ b/lib/money/ecto/money_ecto_map_type.ex
@@ -55,6 +55,10 @@ if Code.ensure_loaded?(Ecto.Type) do
       end
     end
 
+    def load(_, _, _) do
+      :error
+    end
+
     def dump(money, dumper \\ nil, params \\ [])
 
     def dump(%Money{currency: currency, amount: %Decimal{} = amount}, _dumper, _params) do

--- a/mix/schema.ex
+++ b/mix/schema.ex
@@ -10,11 +10,20 @@ defmodule Organization do
     field :revenue,         Money.Ecto.Map.Type, default: Money.new(:AUD, 0)
     field :name,            :string
     field :employee_count,  :integer
+    embeds_many :customers, Customer do
+      field :name, :string
+      field :revenue, Money.Ecto.Map.Type, default: Money.new(:USD, 0)
+    end
     timestamps()
   end
 
   def changeset(organization, params \\ %{}) do
     organization
     |> cast(params, [:payroll])
+    |> cast_embed(:customers, with: &customer_changeset/2)
+  end
+
+  def customer_changeset(customer, params \\ %{}) do
+    cast(customer, params, [:name, :revenue])
   end
 end

--- a/priv/repo/migrations/20500930144804_create_test_table.exs
+++ b/priv/repo/migrations/20500930144804_create_test_table.exs
@@ -9,6 +9,7 @@ defmodule Money.Repo.Migrations.CreateMoneyTable do
       add :tax,             :money_with_currency
       add :value,           :money_with_currency
       add :revenue,         :map
+      add :customers,       {:array, :map}
       timestamps()
     end
   end

--- a/test/money_changeset_test.exs
+++ b/test/money_changeset_test.exs
@@ -8,6 +8,11 @@ defmodule Money.Changeset.Test do
     assert changeset.changes.payroll == Money.new(:JPY, 0)
   end
 
+  test "Changeset default currency in embedded schema" do
+    changeset = Organization.changeset(%Organization{}, %{customers: [%{revenue: "12345.67"}]})
+    assert hd(changeset.changes.customers).changes.revenue == Money.new(:USD, "12345.67")
+  end
+
   test "money positive validation" do
     assert validate_money(test_changeset(), :value, less_than: Money.new(:USD, 200)).valid?
 

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -47,7 +47,7 @@ defmodule Money.Ecto.Test do
                {:ok, %{"amount" => "100", "currency" => "USD"}}
     end
 
-    test "dump and loade a money struct when the locale uses non-default separators" do
+    test "dump and load a money struct when the locale uses non-default separators" do
       Cldr.with_locale("de", Test.Cldr, fn ->
         money = Money.new(:USD, "100,34")
         dumped = Money.Ecto.Map.Type.dump(money)
@@ -55,6 +55,20 @@ defmodule Money.Ecto.Test do
 
         cast = Money.Ecto.Map.Type.load(elem(dumped, 1))
         assert cast == {:ok, money}
+      end)
+    end
+
+    test "loads a money struct from an embedded schema when the locale uses non-default separator" do
+      data = %{
+        "revenue" => %{
+          "amount" => "12345.67",
+          "currency" => "EUR"
+        }
+      }
+
+      Cldr.with_locale("de", Test.Cldr, fn ->
+        customer = Ecto.embedded_load(Organization.Customer, data, :json)
+        assert customer.revenue == Money.new(:EUR, "12345,67")
       end)
     end
   end


### PR DESCRIPTION
This fixes #31.

* [x] Added `embeds_many` field to `Organization` schema in order to test dumping and casting.
* [x] Added one test to ensure `cast_embed/2` works correctly with `Money.Ecto.Map.Type` `:default` option.
* [x] Added one test to ensure loading from an embedded schema works as excepted.

Also, I think it is safer to return `:dump` for both `Money.Ecto.Map.Type` and `Money.Ecto.Composite.Type`. While composite types will not work with embeds, nothing prevents from using it:

*If a programmer uses a composite type as an embedded schema field, it will not raise and behave like it is a `:map`. The programmer might think it works but he actually introduce a very hard to find bug because now loading the field is dependent on the used CLDR locale (bypassing parsing & checks made in `load/3`).*

With `embed_as/3` returning `:dump` for both, the programmer will get an error upfront and know that something is wrong.