### PR TITLE
Treat persisted NaN and Inf values as errors whe loading

### DIFF
--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -39,8 +39,9 @@ if Code.ensure_loaded?(Ecto.Type) do
     def load({currency, amount}, _loader, params) do
       currency = String.trim_trailing(currency)
 
-      with {:ok, currency_code} <- Money.validate_currency(currency) do
-        {:ok, Money.new(currency_code, amount, params)}
+      with {:ok, currency_code} <- Money.validate_currency(currency),
+           %Money{} = money <- Money.new(currency_code, amount, params) do
+        {:ok, money}
       else
         _ -> :error
       end

--- a/lib/money/ecto/money_ecto_map_type.ex
+++ b/lib/money/ecto/money_ecto_map_type.ex
@@ -39,8 +39,9 @@ if Code.ensure_loaded?(Ecto.Type) do
     def load(%{"currency" => currency, "amount" => amount}, _loader, params)
         when is_binary(amount) do
       with {amount, ""} <- Decimal.parse(amount),
-           {:ok, currency} <- Money.validate_currency(currency) do
-        {:ok, Money.new(currency, amount, params)}
+           {:ok, currency} <- Money.validate_currency(currency),
+           %Money{} = money <- Money.new(currency, amount, params) do
+        {:ok, money}
       else
         _ -> :error
       end

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -3,7 +3,7 @@ defmodule Money.Ecto.Test do
 
   describe "Money.Ecto.Composite.Type specific tests" do
     test "load a tuple with an unknown currency code produces an error" do
-      assert Money.Ecto.Composite.Type.load({"ABC", 100}) == :error
+      assert Money.Ecto.Composite.Type.load({"INVALID", 100}) == :error
     end
 
     test "load a tuple produces a Money struct" do

--- a/test/money_ecto_test.exs
+++ b/test/money_ecto_test.exs
@@ -10,6 +10,14 @@ defmodule Money.Ecto.Test do
       assert Money.Ecto.Composite.Type.load({"USD", 100}) == {:ok, Money.new(:USD, 100)}
     end
 
+    test "load treats NaN values as error" do
+      assert Money.Ecto.Composite.Type.load({"USD", "NaN"}) == :error
+    end
+
+    test "load treats Inf values as error" do
+      assert Money.Ecto.Composite.Type.load({"USD", "Inf"}) == :error
+    end
+
     test "dump a money struct" do
       assert Money.Ecto.Composite.Type.dump(Money.new(:USD, 100)) ==
                {:ok, {"USD", Decimal.new(100)}}
@@ -40,6 +48,14 @@ defmodule Money.Ecto.Test do
 
     test "load a json map with an unknown currency code produces an error" do
       assert Money.Ecto.Map.Type.load(%{"currency" => "AAA", "amount" => 100}) == :error
+    end
+
+    test "load treats NaN values as error" do
+      assert Money.Ecto.Map.Type.load(%{"currency" => "USD", "amount" => "NaN"}) == :error
+    end
+
+    test "load treats Inf values as error" do
+      assert Money.Ecto.Map.Type.load(%{"currency" => "USD", "amount" => "Inf"}) == :error
     end
 
     test "dump a money struct" do


### PR DESCRIPTION
Before `:ex_money` 5.12.2, it was possible to persist money values that are no longer valid. When trying to load these values with a version of `:ex_money` > 5.12.2, the field gets set to a value like:
```elixir
%MySchema{
  ...
  my_field: {:error, {Money.InvalidAmountError, "Invalid money amount. Found Decimal.new(\"NaN\")."}},
  ...
}
```

I would expect loading to either fail, or for a `%Money{}` struct to still be returned that bypasses the casting performed by `Money.new/_`. This PR handles the `Money.InvalidAmountError` the same way as invalid currencies.

I originally started down the path of allowing an `:invalid_amount` option to be specified as a parameter on the ecto schema field that would allow controlling what to do such as `:zero`, `:cast`, and `:raise`. Eventually, I decided it was probably best for whoever has any bad data to see the exception raised by the load error and just fix the data in the database; making it an option means it has to be supported for a long time, and a very small number of people are likely to have these values.