### PR TITLE
Delete additional Ecto.Schema options when loading

### DIFF
--- a/lib/money/ecto/money_ecto_composite_type.ex
+++ b/lib/money/ecto/money_ecto_composite_type.ex
@@ -25,6 +25,12 @@ if Code.ensure_loaded?(Ecto.Type) do
       |> Keyword.delete(:field)
       |> Keyword.delete(:schema)
       |> Keyword.delete(:default)
+      |> Keyword.delete(:source)
+      |> Keyword.delete(:autogenerate)
+      |> Keyword.delete(:read_after_writes)
+      |> Keyword.delete(:load_in_query)
+      |> Keyword.delete(:redact)
+      |> Keyword.delete(:skip_default_validation)
     end
 
     # When loading from the database


### PR DESCRIPTION
Problem:  I was attempting to rename one of my fields with a `Money.Ecto.Composite.Type` while keeping the source column in the db the same, following [this strategy](https://fly.io/phoenix-files/migration-recipes/#good-6).  

However, the change caused my tests to fail because the `Money` struct loaded from the db had the `source: :db_col` in the `format_options`.

Proposed Solution:  Deletes additional [Ecto.Schema.field/3 options](https://hexdocs.pm/ecto/Ecto.Schema.html#field/3-options) so they don't get loaded as `format_options`.