### PR TITLE
chore(security): Set search_path for postgres functions

### DIFF
--- a/priv/SQL/postgres/define_minmax_functions.sql
+++ b/priv/SQL/postgres/define_minmax_functions.sql
@@ -3,6 +3,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     expected_currency varchar;
@@ -39,6 +40,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     min numeric;
@@ -74,6 +76,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     expected_currency varchar;
@@ -110,6 +113,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     max numeric;

--- a/priv/SQL/postgres/define_minus_operator.sql
+++ b/priv/SQL/postgres/define_minus_operator.sql
@@ -3,6 +3,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     currency varchar;

--- a/priv/SQL/postgres/define_negate_operator.sql
+++ b/priv/SQL/postgres/define_negate_operator.sql
@@ -3,6 +3,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
     DECLARE
     currency varchar;

--- a/priv/SQL/postgres/define_plus_operator.sql
+++ b/priv/SQL/postgres/define_plus_operator.sql
@@ -3,6 +3,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     currency varchar;

--- a/priv/SQL/postgres/define_sum_function.sql
+++ b/priv/SQL/postgres/define_sum_function.sql
@@ -3,6 +3,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   DECLARE
     expected_currency varchar;
@@ -35,6 +36,7 @@ RETURNS money_with_currency
 IMMUTABLE
 STRICT
 LANGUAGE plpgsql
+SET search_path = ''
 AS $$
   BEGIN
     IF currency_code(agg_state1) = currency_code(agg_state2) THEN

--- a/priv/repo/migrations/20231030034859_add_postgres_money_sum_function.exs
+++ b/priv/repo/migrations/20231030034859_add_postgres_money_sum_function.exs
@@ -9,6 +9,7 @@ defmodule Money.SQL.Repo.Migrations.AddPostgresMoneySumFunction do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           expected_currency varchar;

--- a/priv/repo/migrations/20231030035131_add_postgres_money_plus_operator.exs
+++ b/priv/repo/migrations/20231030035131_add_postgres_money_plus_operator.exs
@@ -9,6 +9,7 @@ defmodule Money.SQL.Repo.Migrations.AddPostgresMoneyPlusOperator do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           currency varchar;

--- a/priv/repo/migrations/20231030035136_add_postgres_money_minmax_functions.exs
+++ b/priv/repo/migrations/20231030035136_add_postgres_money_minmax_functions.exs
@@ -9,6 +9,7 @@ defmodule Money.SQL.Repo.Migrations.AddPostgresMoneyMinmaxFunctions do
       IMMUTABLE
       STRICT
       LANGUAGE plpgsql
+      SET search_path = ''
       AS $$
         DECLARE
           expected_currency varchar;


### PR DESCRIPTION
Adds `SET search_path = ''` to all postgres functions to address security warnings found via the supabase postgres linter.

https://supabase.github.io/splinter/0011_function_search_path_mutable/

> When a function does not have its search_path explicitly set, it inherits the search_path of the current session when it is invoked. This behavior can lead to several problems:
>
> Inconsistency: The function may behave differently depending on the user's search_path settings.
>
> Security Risks: Malicious users could potentially exploit the search_path to direct the function to use unexpected objects, such as tables or other functions, that the malicious user controls

And here's a related CVE from older versions of Postgres: https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058%3A_Protect_Your_Search_Path